### PR TITLE
Support character -> trainer actor type for loading character sheets

### DIFF
--- a/module/pte.mjs
+++ b/module/pte.mjs
@@ -42,8 +42,9 @@ Hooks.once('init', function () {
   // for the base actor/item classes - they are included
   // with the Character/NPC as part of super.defineSchema()
   CONFIG.Actor.dataModels = {
-    character: models.PTECharacter,
-    npc: models.PTENPC
+    trainer: models.PTECharacter,
+    pokemon: models.PTECharacter,
+    // npc: models.PTENPC
   }
   CONFIG.Item.documentClass = PTEItem;
   CONFIG.Item.dataModels = {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -49,15 +49,16 @@ export class PTEActorSheet extends ActorSheet {
     // Adding a pointer to CONFIG.POKEMON_TABLETOP_EVOLUTION
     context.config = CONFIG.POKEMON_TABLETOP_EVOLUTION;
 
-    // Prepare character data and items.
-    if (actorData.type == 'character') {
+    // Prepare trainer data and items.
+    if (actorData.type == 'trainer') {
       this._prepareItems(context);
       this._prepareCharacterData(context);
     }
 
-    // Prepare NPC data and items.
-    if (actorData.type == 'npc') {
+    // Prepare Pokemon data and items.
+    if (actorData.type == 'pokemon') {
       this._prepareItems(context);
+      this._prepareCharacterData(context);
     }
 
     // Enrich biography info for display
@@ -117,6 +118,7 @@ export class PTEActorSheet extends ActorSheet {
       8: [],
       9: [],
     };
+
 
     // Iterate through items, allocating to containers
     for (let i of context.items) {

--- a/templates/actor/actor-trainer-sheet.hbs
+++ b/templates/actor/actor-trainer-sheet.hbs
@@ -2,12 +2,12 @@
 
   {{!-- Sheet Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
+    <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100" />
     <div class="header-fields">
-      <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" placeholder="Name"/></h1>
+      <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" placeholder="Name" /></h1>
       {{!-- The grid classes are defined in scss/global/_grid.scss. To use,
       use both the "grid" and "grid-Ncol" class where "N" can be any number
-      from 1 to 12 and will create that number of columns.  --}}
+      from 1 to 12 and will create that number of columns. --}}
       <div class="resources grid grid-3col">
 
         {{!-- "flex-group-center" is also defined in the _grid.scss file
@@ -16,25 +16,26 @@
         <div class="resource flex-group-center">
           <label for="system.health.value" class="resource-label">Health</label>
           <div class="resource-content flexrow flex-center flex-between">
-          <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number"/>
-          <span> / </span>
-          <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number"/>
+            <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number" />
+            <span> / </span>
+            <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number" />
           </div>
         </div>
 
         <div class="resource flex-group-center">
           <label for="system.power.value" class="resource-label">AP</label>
           <div class="resource-content flexrow flex-center flex-between">
-          <input type="text" name="system.power.value" value="{{system.power.value}}" data-dtype="Number"/>
-          <span> / </span>
-          <input type="text" name="system.power.max" value="{{system.power.max}}" data-dtype="Number"/>
+            <input type="text" name="system.power.value" value="{{system.power.value}}" data-dtype="Number" />
+            <span> / </span>
+            <input type="text" name="system.power.max" value="{{system.power.max}}" data-dtype="Number" />
           </div>
         </div>
 
         <div class="resource flex-group-center">
           <label for="system.attributes.level.value" class="resource-label">Level</label>
           <div class="resource-content flexrow flex-center flex-between">
-          <input type="text" name="system.attributes.level.value" value="{{system.attributes.level.value}}" data-dtype="Number"/>
+            <input type="text" name="system.attributes.level.value" value="{{system.attributes.level.value}}"
+              data-dtype="Number" />
           </div>
         </div>
 
@@ -62,13 +63,18 @@
 
           {{!-- The grid classes are defined in scss/global/_grid.scss. To use,
           use both the "grid" and "grid-Ncol" class where "N" can be any number
-          from 1 to 12 and will create that number of columns.  --}}
+          from 1 to 12 and will create that number of columns. --}}
           <div class="abilities flexcol">
             {{#each system.abilities as |ability key|}}
             <div class="ability flexrow flex-group-center">
-              <label for="system.abilities.{{key}}.value" class="resource-label rollable flexlarge align-left" data-roll="d20+@abilities.{{key}}.mod" data-label="{{localize (lookup @root.config.abilities key)}}">{{localize (lookup @root.config.abilities key)}}</label>
-              <input type="text" name="system.abilities.{{key}}.value" value="{{ability.value}}" data-dtype="Number"/>
-              <span class="ability-mod rollable" data-roll="d20+@abilities.{{key}}.mod" data-label="{{localize (lookup @root.config.abilities key)}}">{{numberFormat ability.mod decimals=0 sign=true}}</span>
+              <label for="system.abilities.{{key}}.value" class="resource-label rollable flexlarge align-left"
+                data-roll="d20+@abilities.{{key}}.mod"
+                data-label="{{localize (lookup @root.config.abilities key)}}">{{localize (lookup @root.config.abilities
+                key)}}</label>
+              <input type="text" name="system.abilities.{{key}}.value" value="{{ability.value}}" data-dtype="Number" />
+              <span class="ability-mod rollable" data-roll="d20+@abilities.{{key}}.mod"
+                data-label="{{localize (lookup @root.config.abilities key)}}">{{numberFormat ability.mod decimals=0
+                sign=true}}</span>
             </div>
             {{/each}}
           </div>
@@ -76,7 +82,8 @@
 
         {{!-- For the main features list, span the right two columns --}}
         <section class="main grid-span-2">
-          {{!-- This is a Handlebars partial. They're stored in the `/parts` folder next to this sheet, and defined in module/helpers/templates.mjs --}}
+          {{!-- This is a Handlebars partial. They're stored in the `/parts` folder next to this sheet, and defined in
+          module/helpers/templates.mjs --}}
           {{> "systems/pte/templates/actor/parts/actor-features.hbs"}}
         </section>
 
@@ -91,7 +98,7 @@
 
     {{!-- Owned Items Tab --}}
     <div class="tab items" data-group="primary" data-tab="items">
-       {{> "systems/pte/templates/actor/parts/actor-items.hbs"}}
+      {{> "systems/pte/templates/actor/parts/actor-items.hbs"}}
     </div>
 
     {{!-- Owned Spells Tab --}}


### PR DESCRIPTION
Changes to get the default character sheet working again after the template.json changes.


actor-character-sheet.hbs → templates/actor/actor-trainer-sheet.hbs is just for the rename, but looks bigger due to formatting changes from applying coding standards.